### PR TITLE
Update ghostwriter/coding-standard to version dev-main#2c87af6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4078,12 +4078,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "fc22bc00b93e0e1ab5ddd10f12000dd357737fb4"
+                "reference": "2c87af6372240695378392ebcca903b9fc9df172"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/fc22bc00b93e0e1ab5ddd10f12000dd357737fb4",
-                "reference": "fc22bc00b93e0e1ab5ddd10f12000dd357737fb4",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/2c87af6372240695378392ebcca903b9fc9df172",
+                "reference": "2c87af6372240695378392ebcca903b9fc9df172",
                 "shasum": ""
             },
             "require": {
@@ -4257,7 +4257,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-23T17:21:01+00:00"
+            "time": "2025-12-25T17:00:18+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#fc22bc0` to `dev-main#2c87af6`.

This pull request changes the following file(s): 

- Update `composer.lock`