### PR TITLE
Update ghostwriter/coding-standard to version dev-main#f745185

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4078,12 +4078,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "2c87af6372240695378392ebcca903b9fc9df172"
+                "reference": "f74518581c7da70e84e6aa3eb4d52b79db84b226"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/2c87af6372240695378392ebcca903b9fc9df172",
-                "reference": "2c87af6372240695378392ebcca903b9fc9df172",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/f74518581c7da70e84e6aa3eb4d52b79db84b226",
+                "reference": "f74518581c7da70e84e6aa3eb4d52b79db84b226",
                 "shasum": ""
             },
             "require": {
@@ -4257,7 +4257,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-25T17:00:18+00:00"
+            "time": "2025-12-29T11:57:39+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#2c87af6` to `dev-main#f745185`.

This pull request changes the following file(s): 

- Update `composer.lock`