### PR TITLE
Update ghostwriter/coding-standard to version dev-main#0dc1abd

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4078,12 +4078,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "dde737d153a4060c3c2d792ad50e740d356a34cf"
+                "reference": "0dc1abd5fda3db8a68519604c991f498932048e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/dde737d153a4060c3c2d792ad50e740d356a34cf",
-                "reference": "dde737d153a4060c3c2d792ad50e740d356a34cf",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/0dc1abd5fda3db8a68519604c991f498932048e0",
+                "reference": "0dc1abd5fda3db8a68519604c991f498932048e0",
                 "shasum": ""
             },
             "require": {
@@ -4257,7 +4257,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-31T18:02:44+00:00"
+            "time": "2026-01-01T01:56:11+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#dde737d` to `dev-main#0dc1abd`.

This pull request changes the following file(s): 

- Update `composer.lock`