### PR TITLE
Update ghostwriter/shell to version 0.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "ghostwriter/container": "^6.0.1",
         "ghostwriter/event-dispatcher": "^6.0.2",
         "ghostwriter/filesystem": "^0.1.2",
-        "ghostwriter/shell": "^0.1.2",
+        "ghostwriter/shell": "^0.1.4",
         "vimeo/psalm": "^6.14.3"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20bc6286b38373348198757874ba2dce",
+    "content-hash": "ed205c6b7af8964ffc8b273b4d1eb9b3",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1556,16 +1556,16 @@
         },
         {
             "name": "ghostwriter/shell",
-            "version": "0.1.2",
+            "version": "0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/shell.git",
-                "reference": "e6367b96cd6be790291bc23c1e5d3aa607335109"
+                "reference": "52baa393e18d9db93f479c96241d6d644ec07f10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/shell/zipball/e6367b96cd6be790291bc23c1e5d3aa607335109",
-                "reference": "e6367b96cd6be790291bc23c1e5d3aa607335109",
+                "url": "https://api.github.com/repos/ghostwriter/shell/zipball/52baa393e18d9db93f479c96241d6d644ec07f10",
+                "reference": "52baa393e18d9db93f479c96241d6d644ec07f10",
                 "shasum": ""
             },
             "require": {
@@ -1577,7 +1577,7 @@
                 "ghostwriter/container": "^6.0.1",
                 "mockery/mockery": "^1.6.12",
                 "phpunit/phpunit": "^12.5.7",
-                "symfony/var-dumper": "^8.0.3"
+                "symfony/var-dumper": "^8.0.4"
             },
             "type": "library",
             "extra": {
@@ -1627,7 +1627,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-25T08:43:34+00:00"
+            "time": "2026-01-25T16:15:33+00:00"
         },
         {
             "name": "kelunik/certificate",


### PR DESCRIPTION
Updates the `ghostwriter/shell` dependency from `0.1.2` to `0.1.4`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`