### PR TITLE
Update ghostwriter/coding-standard to version dev-main#7f1cf5a

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4079,12 +4079,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "146c887470187c16bef0c46bfde0ad6d1aaf4a54"
+                "reference": "7f1cf5a6e73bdbb5b090a5e854e7e0389b5177b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/146c887470187c16bef0c46bfde0ad6d1aaf4a54",
-                "reference": "146c887470187c16bef0c46bfde0ad6d1aaf4a54",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/7f1cf5a6e73bdbb5b090a5e854e7e0389b5177b8",
+                "reference": "7f1cf5a6e73bdbb5b090a5e854e7e0389b5177b8",
                 "shasum": ""
             },
             "require": {
@@ -4143,7 +4143,7 @@
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.7.0",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^12.5.7",
+                "phpunit/phpunit": "^12.5.8",
                 "symfony/process": "^8.0.4",
                 "symfony/var-dumper": "^8.0.4"
             },
@@ -4259,7 +4259,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-26T20:03:17+00:00"
+            "time": "2026-01-27T07:03:02+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#146c887` to `dev-main#7f1cf5a`.

This pull request changes the following file(s): 

- Update `composer.lock`