### PR TITLE
Update ghostwriter/console to version 0.2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "ext-mbstring": "*",
         "ext-simplexml": "*",
         "ghostwriter/config": "^2.1.3",
-        "ghostwriter/console": "^0.2.2",
+        "ghostwriter/console": "^0.2.3",
         "ghostwriter/container": "^7.0.1",
         "ghostwriter/event-dispatcher": "^6.1.1",
         "ghostwriter/filesystem": "^0.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25a28c21b247f07bf35973c4581dde0d",
+    "content-hash": "17de7602f6a64c74d8a6a768e55bac68",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1421,22 +1421,22 @@
         },
         {
             "name": "ghostwriter/console",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/console.git",
-                "reference": "de63839d21eb9ed8632ed9b03dccfc9f85e15404"
+                "reference": "205f0ef525810df84021b9a86e0068d2910b24e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/console/zipball/de63839d21eb9ed8632ed9b03dccfc9f85e15404",
-                "reference": "de63839d21eb9ed8632ed9b03dccfc9f85e15404",
+                "url": "https://api.github.com/repos/ghostwriter/console/zipball/205f0ef525810df84021b9a86e0068d2910b24e6",
+                "reference": "205f0ef525810df84021b9a86e0068d2910b24e6",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "ghostwriter/config": "^2.1.1",
-                "ghostwriter/container": "^7.0.0",
+                "ghostwriter/config": "^2.1.3",
+                "ghostwriter/container": "^7.0.1",
                 "php": "~8.4.0 || ~8.5.0",
                 "symfony/console": "^8.0.8"
             },
@@ -1496,7 +1496,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-20T16:54:31+00:00"
+            "time": "2026-04-23T04:43:20+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `ghostwriter/console` dependency from `0.2.2` to `0.2.3`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`